### PR TITLE
local changes prior syncing with GitHub edits

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -211,6 +211,8 @@ workflow {
         AnnotateKmers(sig_kmer, reftxt, gff_files)
         genehit = AnnotateKmers.out.annotated_kmers_out
 
-        GeneHitPlot(genehit)
+        plot_script = Channel.value(file("${projectDir}/scripts/gene_hit_summary_plot.R"))
+
+        GeneHitPlot(genehit, plot_script)
     }
 }

--- a/modules/BaktaAnnotate.nf
+++ b/modules/BaktaAnnotate.nf
@@ -2,7 +2,7 @@
 process BaktaAnnotate {
     tag "${sample_id}"
     
-    container "quay.io/biocontainers/bakta:1.9.4--pyhdfd78af_0"
+    container "quay.io/biocontainers/bakta:1.11.3--pyhdfd78af_0"
 
     publishDir "${params.outdir}/bakta", mode:'copy', overwrite: true
 

--- a/modules/SignificantKmerAnalysis.nf
+++ b/modules/SignificantKmerAnalysis.nf
@@ -54,7 +54,7 @@ process WriteReferenceText {
     while IFS=, read -r sample_id assembly_path
     do
         if [[ \${sample_id} != "sample_id" ]]; then
-            echo -e "\${assembly_path}\\t\${sample_id}.gff\\tdraft"
+            echo -e "\${assembly_path}\\t\${sample_id}.gff3\\tdraft"
         fi
     done < "${manifest_ch}" >> "${output_file}"
     """
@@ -85,12 +85,13 @@ process GeneHitPlot {
 
     input:
     path genehit
+    path plot_script
 
     output:
     path "*.pdf", emit: genehit_plot_out
 
     script:
     """
-    Rscript ${projectDir}/scripts/gene_hit_summary_plot.R 
+    Rscript ${plot_script} ${genehit} 
     """
 }


### PR DESCRIPTION
Some small bugs I encountered and fixed during my test run on the Cambridge HPC. 

1) Change suffix in line 57 in SignificantKmerAnalysis.nf because for some reason the GFF files passed to the process now has .gff3 suffix instead of .gff, while the paths in references.txt file generated by the process WriteReferenceText are .gff in suffix. 

2) Change line 214-216 of main.nf (subsequently line 88 and line 95 of SignificantKmerAnalysis.nf) because it seems that we are calling an absolute path on the host from inside the container when trying to run the R script, and when the task runs under Singularity, that host path isn’t mounted in the container, so Rscript can’t see it and errors with “No such file or directory”. I get around this by now adding a plot_script channel to pass it to the process, and Nextflow now sees the R script as a file and carries it to the work directory. 

3) Change line 5 in BaktaAnnotate.nf to update the container. 

By the way I also made some minor changes on the input file examples (e.g. cleaning the file path to hide the Sanger-ness in them) and edited README to ensure it targets the communication to broader users. 